### PR TITLE
Ignore artifacts and document local model regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ runs/
 node_modules/
 frontend/node_modules/
 frontend/dist/
+artifacts/
+*.joblib

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ tests/                    # Pytest integration tests, including API coverage
 
    This reads `data/sentiment_train.jsonl` and writes
    `artifacts/sentiment_pipeline.joblib` used by the production configuration.
+   The serialized artifact is intentionally excluded from version control, so
+   contributors should run `python scripts/train_sentiment_model.py` locally
+   whenever the model needs to be regenerated (for example after updating the
+   training data) before executing workflows that depend on it.
 
 3. **Run an evaluation using either of the provided configurations:**
 


### PR DESCRIPTION
## Summary
- prevent serialized sentiment artifacts from being tracked by ignoring `artifacts/` and `*.joblib`
- update the README to remind contributors to run `scripts/train_sentiment_model.py` locally whenever they need to refresh the model artifact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdff41627c8328bce1cdec381233b1