### PR TITLE
Implement full evaluation stack with API and dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ runs/
 node_modules/
 frontend/node_modules/
 frontend/dist/
+artifacts/
+*.joblib

--- a/README.md
+++ b/README.md
@@ -1,102 +1,111 @@
 # Evaluation Agent
 
-This repository contains an automated agent that evaluates AI models against configurable
-datasets and metrics. It now ships with a production-ready workflow for sentiment
-classification, a FastAPI backend that stores runs in SQLite, and a React dashboard for
-exploring evaluation results.
+This repository contains an end-to-end evaluation stack for text-classification models. It ships with
 
-## Features
+- a modular Python evaluation agent capable of orchestrating datasets, model adapters, and metrics,
+- a FastAPI service with a SQLite-backed run history, and
+- a Vite + React dashboard for visualising metrics and predictions.
 
-- Modular registries for datasets, models, metrics, and tasks.
-- JSON-based configuration system with automatic path resolution and SQLite persistence.
-- Keyword baseline **and** a trained scikit-learn TF-IDF + logistic regression model.
-- Accuracy, macro/weighted precision/recall/F1, confusion matrix, and label distribution metrics.
-- FastAPI service with REST endpoints for triggering runs and browsing historic executions.
-- React + Material UI dashboard with interactive charts and a prediction explorer.
-- Command line interface for both single-run execution and launching the API server.
+The default workflow benchmarks sentiment analysis models on small JSONL datasets. Two presets are
+provided out of the box: a deterministic keyword baseline and a scikit-learn TF-IDF + logistic
+regression model that can be re-trained locally.
 
 ## Project Layout
 
 ```
-configs/                  # Evaluation configurations for keyword and sklearn models
+configs/                  # Evaluation configurations (keyword baseline & sklearn)
 data/                     # Training and evaluation datasets (JSONL)
-frontend/                 # Vite + React dashboard for the evaluation API
-scripts/                  # Utility scripts (e.g., training the scikit-learn model)
-src/eval_agent/           # Evaluation agent source code
-tests/                    # Pytest integration tests, including API coverage
+frontend/                 # Vite + React dashboard that consumes the FastAPI API
+scripts/                  # Utility scripts (e.g., training the sklearn model)
+src/eval_agent/           # Python evaluation agent, API service, and persistence
+tests/                    # Pytest-based regression tests
 ```
 
-## Getting Started
+## Quickstart
 
-1. **Install Python dependencies in editable mode:**
+### 1. Install dependencies
 
-   ```bash
-   pip install -e .
-   ```
+```bash
+pip install -e .
+```
 
-2. **(Optional) Re-train the bundled scikit-learn sentiment model:**
+The Python package depends on FastAPI, uvicorn, and scikit-learn. Frontend dependencies are managed
+with `npm` inside the `frontend/` directory.
 
-   ```bash
-   python scripts/train_sentiment_model.py
-   ```
+### 2. (Optional) Train the scikit-learn sentiment model
 
-   This reads `data/sentiment_train.jsonl` and writes
-   `artifacts/sentiment_pipeline.joblib` used by the production configuration.
+The serialized pipeline is intentionally excluded from version control. Run the helper script whenever
+you need to refresh the artifact:
 
-3. **Run an evaluation using either of the provided configurations:**
+```bash
+python scripts/train_sentiment_model.py
+```
 
-   ```bash
-   # Keyword baseline
-   python -m eval_agent.cli run configs/sentiment_keyword.json
+This reads `data/sentiment_train.jsonl`, evaluates on `data/sentiment_eval.jsonl`, and writes
+`artifacts/sentiment_pipeline.joblib` used by the `sentiment-sklearn` preset.
 
-   # Trained scikit-learn model
-   python -m eval_agent.cli run configs/sentiment_sklearn.json
-   ```
+### 3. Execute an evaluation from the CLI
 
-   The agent emits JSON artifacts in `runs/` (ignored by git) and records each run in
-   `runs/evaluations.db` for the API/dashboard.
+Two configuration files live under `configs/`:
 
-4. **Launch the API server:**
+```bash
+# Keyword baseline
+python -m eval_agent.cli run configs/sentiment_keyword.json
 
-   ```bash
-   python -m eval_agent.cli serve --host 0.0.0.0 --port 8000
-   ```
+# Trained scikit-learn pipeline (requires the artifact from step 2)
+python -m eval_agent.cli run configs/sentiment_sklearn.json
+```
 
-   The API exposes endpoints under `/api/*` and persists runs to SQLite. See
-   `src/eval_agent/api/app.py` for the schema.
+Results are written to `runs/` as JSON (ignored by git). The CLI will also print a summary and, by
+default, the individual predictions.
 
-5. **Start the React dashboard (in a separate terminal):**
+### 4. Launch the API service
 
-   ```bash
-   cd frontend
-   npm install
-   npm run dev
-   ```
+```bash
+python -m eval_agent.cli serve --host 0.0.0.0 --port 8000
+```
 
-   Override the API base URL by setting `VITE_API_BASE_URL` if the backend runs on a
-   different host/port.
+Available endpoints include:
 
-6. **Run the Python test suite:**
+- `GET /api/configs` — preset configurations exposed by the dashboard
+- `GET /api/runs` — list of historical runs stored in `runs/evaluations.db`
+- `POST /api/runs` — execute a configuration immediately
+- `GET /api/runs/{id}` — retrieve metrics and predictions for a single run
 
-   ```bash
-   pytest
-   ```
+All runs triggered through the API are persisted to SQLite with links to the JSON artifacts on disk.
 
-   Frontend builds are also covered by running `npm run build` inside the `frontend/`
-   directory.
+### 5. Start the React dashboard
 
-## Extending the Agent
+In a separate terminal:
 
-- Register new datasets by creating a subclass of `eval_agent.datasets.base.Dataset` and
-  decorating it with `@DATASET_REGISTRY.register("your-dataset-name")`.
-- Add new model integrations by inheriting from `eval_agent.models.base.ModelAdapter` and
-  registering via `@MODEL_REGISTRY.register("your-model")`.
-- Implement additional metrics by extending `eval_agent.metrics.base.Metric` and registering
-  them with `@METRIC_REGISTRY.register("metric-name")`.
-- Create new tasks by subclassing `eval_agent.tasks.base.Task` and registering with
-  `@TASK_REGISTRY.register("task-name")`.
-- Surface new presets via the API by adding entries to `PRESET_CONFIGS` in
-  `src/eval_agent/api/app.py`; the React UI automatically lists these options.
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-Each component becomes available for use in configuration files and through the API
-immediately after registration.
+By default the dashboard talks to `http://localhost:8000/api`. Override the target by exporting
+`VITE_API_BASE_URL` before running `npm run dev` or `npm run build`.
+
+### 6. Run the test suite
+
+```bash
+pytest
+```
+
+The tests cover the keyword baseline configuration to guard against regressions in the evaluation
+engine.
+
+## Extending the agent
+
+- Register new datasets by creating a subclass of `eval_agent.datasets.base.Dataset` and decorating it
+  with `@DATASET_REGISTRY.register("your-dataset-name")`.
+- Add model adapters by subclassing `eval_agent.models.base.ModelAdapter` and registering via
+  `@MODEL_REGISTRY.register("your-model")`.
+- Implement additional metrics by extending `eval_agent.metrics.base.Metric` and registering with
+  `@METRIC_REGISTRY.register("metric-name")`.
+- Surface new presets in the API/dashboard by updating `PRESET_CONFIGS` in
+  `src/eval_agent/api/app.py`.
+
+Each component becomes available in configuration files, through the CLI, and via the HTTP API as soon
+as it is registered.

--- a/configs/sentiment_sklearn.json
+++ b/configs/sentiment_sklearn.json
@@ -1,12 +1,11 @@
 {
-  "name": "sentiment-keyword-baseline",
+  "name": "sentiment-sklearn-tfidf",
   "task": "text-classification",
   "model": {
-    "type": "keyword-matching",
+    "type": "sklearn-pipeline",
     "parameters": {
-      "positive_keywords": ["love", "fantastic", "outstanding", "charm"],
-      "negative_keywords": ["terrible", "worst", "awful", "rude"],
-      "default_label": "neutral"
+      "artifact_path": "../artifacts/sentiment_pipeline.joblib",
+      "name": "sentiment-logreg"
     }
   },
   "dataset": {
@@ -18,6 +17,7 @@
   "metrics": [
     {"type": "accuracy", "name": "accuracy"},
     {"type": "precision", "name": "precision_macro", "parameters": {"average": "macro"}},
+    {"type": "precision", "name": "precision_weighted", "parameters": {"average": "weighted"}},
     {"type": "recall", "name": "recall_macro", "parameters": {"average": "macro"}},
     {"type": "f1", "name": "f1_macro", "parameters": {"average": "macro"}},
     {"type": "confusion-matrix", "name": "confusion_matrix"},

--- a/data/sentiment_train.jsonl
+++ b/data/sentiment_train.jsonl
@@ -1,0 +1,18 @@
+{"id": 1, "text": "I love how responsive the support team is.", "label": "positive"}
+{"id": 2, "text": "This update is terrible and broke everything.", "label": "negative"}
+{"id": 3, "text": "The product is fine, does what it says.", "label": "neutral"}
+{"id": 4, "text": "Outstanding quality and fantastic performance.", "label": "positive"}
+{"id": 5, "text": "Worst purchase ever, completely useless.", "label": "negative"}
+{"id": 6, "text": "Pretty average overall, nothing special.", "label": "neutral"}
+{"id": 7, "text": "Absolutely thrilled with the new features!", "label": "positive"}
+{"id": 8, "text": "Customer service was rude and unhelpful.", "label": "negative"}
+{"id": 9, "text": "It's okay for the price you pay.", "label": "neutral"}
+{"id": 10, "text": "What an amazing experience from start to finish.", "label": "positive"}
+{"id": 11, "text": "The build quality is awful and feels cheap.", "label": "negative"}
+{"id": 12, "text": "Nothing to complain about, it's acceptable.", "label": "neutral"}
+{"id": 13, "text": "Superb craftsmanship and delightful design.", "label": "positive"}
+{"id": 14, "text": "I had a bad experience with shipping delays.", "label": "negative"}
+{"id": 15, "text": "The device works as expected, no surprises.", "label": "neutral"}
+{"id": 16, "text": "Fantastic taste and lovely presentation.", "label": "positive"}
+{"id": 17, "text": "Horrible interface and confusing layout.", "label": "negative"}
+{"id": 18, "text": "The app is fine but could use more polish.", "label": "neutral"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Evaluation Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "evaluation-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.11",
+    "@mui/material": "^5.14.11",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Container,
+  Grid,
+  Snackbar,
+  Stack,
+  Typography
+} from '@mui/material';
+import ConfigSelector from './components/ConfigSelector';
+import RunDetail from './components/RunDetail';
+import RunList from './components/RunList';
+import {
+  ConfigInfo,
+  RunDetail as RunDetailType,
+  RunSummary,
+  fetchConfigs,
+  fetchRun,
+  fetchRuns,
+  triggerRun
+} from './api';
+
+const App = () => {
+  const [configs, setConfigs] = useState<ConfigInfo[]>([]);
+  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [selectedRun, setSelectedRun] = useState<RunDetailType | null>(null);
+  const [selectedRunId, setSelectedRunId] = useState<number | null>(null);
+  const [selectedConfig, setSelectedConfig] = useState<string>('');
+  const [triggering, setTriggering] = useState(false);
+  const [savePredictions, setSavePredictions] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initialize = async () => {
+      try {
+        const [configData, runsData] = await Promise.all([fetchConfigs(), fetchRuns()]);
+        setConfigs(configData);
+        setRuns(runsData);
+        if (!selectedConfig && configData.length > 0) {
+          setSelectedConfig(configData[0].name);
+        }
+        if (runsData.length > 0) {
+          const runId = runsData[0].id;
+          setSelectedRunId(runId);
+          loadRunDetail(runId);
+        }
+      } catch (err) {
+        setError('Failed to initialize dashboard. Ensure the API is reachable.');
+      }
+    };
+    initialize();
+  }, []);
+
+  const loadRuns = async () => {
+    setRunsLoading(true);
+    try {
+      const runData = await fetchRuns();
+      setRuns(runData);
+    } catch (err) {
+      setError('Failed to fetch evaluation runs.');
+    } finally {
+      setRunsLoading(false);
+    }
+  };
+
+  const loadRunDetail = async (runId: number) => {
+    setDetailLoading(true);
+    try {
+      const detail = await fetchRun(runId);
+      setSelectedRun(detail);
+      setSelectedRunId(detail.id);
+    } catch (err) {
+      setError(`Failed to load run ${runId}.`);
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const handleTriggerRun = async () => {
+    if (!selectedConfig) return;
+    setTriggering(true);
+    try {
+      const detail = await triggerRun(selectedConfig, savePredictions);
+      setSuccess(`Run '${detail.name}' completed successfully.`);
+      setSelectedRun(detail);
+      setSelectedRunId(detail.id);
+      await loadRuns();
+    } catch (err) {
+      setError('Failed to execute evaluation. Check server logs for more details.');
+    } finally {
+      setTriggering(false);
+    }
+  };
+
+  const handleRunSelection = (runId: number) => {
+    loadRunDetail(runId);
+  };
+
+  const selectedConfigInfo = useMemo(
+    () => configs.find((config) => config.name === selectedConfig),
+    [configs, selectedConfig]
+  );
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={2}>
+          <Box>
+            <Typography variant="h4" fontWeight={700} gutterBottom>
+              Evaluation Dashboard
+            </Typography>
+            {selectedConfigInfo && (
+              <Typography variant="body2" color="text.secondary">
+                API base: {import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api'}
+              </Typography>
+            )}
+          </Box>
+          <ConfigSelector
+            configs={configs}
+            selectedConfig={selectedConfig}
+            onSelect={setSelectedConfig}
+            onTrigger={handleTriggerRun}
+            triggering={triggering}
+            savePredictions={savePredictions}
+            onSavePredictionsChange={setSavePredictions}
+          />
+        </Box>
+
+        <Grid container spacing={3} alignItems="stretch">
+          <Grid item xs={12} md={4}>
+            <RunList
+              runs={runs}
+              selectedRunId={selectedRunId}
+              onSelect={handleRunSelection}
+              loading={runsLoading}
+            />
+          </Grid>
+          <Grid item xs={12} md={8}>
+            <RunDetail run={selectedRun} loading={detailLoading} />
+          </Grid>
+        </Grid>
+      </Stack>
+
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert severity="error" onClose={() => setError(null)} sx={{ width: '100%' }}>
+          {error}
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={Boolean(success)}
+        autoHideDuration={4000}
+        onClose={() => setSuccess(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert severity="success" onClose={() => setSuccess(null)} sx={{ width: '100%' }}>
+          {success}
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+};
+
+export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,65 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000/api'
+});
+
+export interface Metric {
+  name: string;
+  value: number;
+  details: Record<string, unknown>;
+}
+
+export interface Prediction {
+  uid: string;
+  inputs: Record<string, unknown>;
+  expected_output: unknown;
+  predicted_output: unknown;
+  metadata: Record<string, unknown>;
+}
+
+export interface RunSummary {
+  id: number;
+  name: string;
+  task: string;
+  config_name: string;
+  config_path: string;
+  started_at: string;
+  completed_at: string;
+  duration: number;
+  metrics: Metric[];
+}
+
+export interface RunDetail extends RunSummary {
+  predictions: Prediction[];
+}
+
+export interface ConfigInfo {
+  name: string;
+  path: string;
+  description?: string | null;
+}
+
+export async function fetchConfigs(): Promise<ConfigInfo[]> {
+  const { data } = await apiClient.get<ConfigInfo[]>('/configs');
+  return data;
+}
+
+export async function fetchRuns(): Promise<RunSummary[]> {
+  const { data } = await apiClient.get<RunSummary[]>('/runs');
+  return data;
+}
+
+export async function fetchRun(runId: number): Promise<RunDetail> {
+  const { data } = await apiClient.get<RunDetail>(`/runs/${runId}`);
+  return data;
+}
+
+export async function triggerRun(config: string, savePredictions?: boolean): Promise<RunDetail> {
+  const payload: Record<string, unknown> = { config };
+  if (typeof savePredictions === 'boolean') {
+    payload.save_predictions = savePredictions;
+  }
+  const { data } = await apiClient.post<RunDetail>('/runs', payload);
+  return data;
+}

--- a/frontend/src/components/ConfigSelector.tsx
+++ b/frontend/src/components/ConfigSelector.tsx
@@ -1,0 +1,83 @@
+import { FC } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Switch,
+  Typography
+} from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { ConfigInfo } from '../api';
+
+interface ConfigSelectorProps {
+  configs: ConfigInfo[];
+  selectedConfig: string;
+  onSelect: (config: string) => void;
+  onTrigger: () => void;
+  triggering: boolean;
+  savePredictions: boolean;
+  onSavePredictionsChange: (value: boolean) => void;
+}
+
+const ConfigSelector: FC<ConfigSelectorProps> = ({
+  configs,
+  selectedConfig,
+  onSelect,
+  onTrigger,
+  triggering,
+  savePredictions,
+  onSavePredictionsChange
+}) => {
+  return (
+    <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+      <FormControl sx={{ minWidth: 220 }} size="small">
+        <InputLabel id="config-select-label">Configuration</InputLabel>
+        <Select
+          labelId="config-select-label"
+          label="Configuration"
+          value={selectedConfig}
+          onChange={(event) => onSelect(event.target.value)}
+        >
+          {configs.map((config) => (
+            <MenuItem key={config.name} value={config.name}>
+              <Box>
+                <Typography variant="body1" fontWeight={600}>
+                  {config.name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {config.path}
+                </Typography>
+              </Box>
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControlLabel
+        control={
+          <Switch
+            checked={savePredictions}
+            onChange={(event) => onSavePredictionsChange(event.target.checked)}
+            size="small"
+          />
+        }
+        label="Save predictions"
+      />
+
+      <Button
+        variant="contained"
+        startIcon={<PlayArrowIcon />}
+        onClick={onTrigger}
+        disabled={!selectedConfig || triggering}
+      >
+        {triggering ? 'Running…' : 'Run Evaluation'}
+      </Button>
+    </Box>
+  );
+};
+
+export default ConfigSelector;

--- a/frontend/src/components/MetricsCards.tsx
+++ b/frontend/src/components/MetricsCards.tsx
@@ -1,0 +1,55 @@
+import { FC } from 'react';
+import { Grid, Paper, Typography } from '@mui/material';
+import { Metric } from '../api';
+
+interface MetricsCardsProps {
+  metrics: Metric[];
+}
+
+const shouldDisplay = (metric: Metric) => {
+  const name = metric.name.toLowerCase();
+  return !(name.includes('distribution') || name.includes('confusion'));
+};
+
+const formatMetricValue = (value: number) => {
+  if (Number.isNaN(value)) {
+    return '—';
+  }
+  if (value <= 1) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return value.toFixed(3);
+};
+
+const prettifyName = (name: string) =>
+  name
+    .replace(/[_-]/g, ' ')
+    .split(' ')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const MetricsCards: FC<MetricsCardsProps> = ({ metrics }) => {
+  const displayMetrics = metrics.filter(shouldDisplay);
+  if (!displayMetrics.length) {
+    return null;
+  }
+
+  return (
+    <Grid container spacing={2} sx={{ mb: 2 }}>
+      {displayMetrics.map((metric) => (
+        <Grid item xs={12} sm={6} md={3} key={metric.name}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="subtitle2" color="text.secondary">
+              {prettifyName(metric.name)}
+            </Typography>
+            <Typography variant="h4" fontWeight={600} mt={1}>
+              {formatMetricValue(metric.value)}
+            </Typography>
+          </Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+export default MetricsCards;

--- a/frontend/src/components/PredictionTable.tsx
+++ b/frontend/src/components/PredictionTable.tsx
@@ -1,0 +1,88 @@
+import { FC } from 'react';
+import {
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { Prediction } from '../api';
+
+interface PredictionTableProps {
+  predictions: Prediction[];
+  limit?: number;
+}
+
+const PredictionTable: FC<PredictionTableProps> = ({ predictions, limit = 50 }) => {
+  if (!predictions.length) {
+    return (
+      <Paper variant="outlined" sx={{ p: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          No predictions available for this run.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  const displayed = predictions.slice(0, limit);
+
+  const renderProbabilities = (metadata: Record<string, unknown>) => {
+    const probabilities = metadata?.probabilities as Record<string, number> | undefined;
+    if (!probabilities) {
+      return null;
+    }
+    const sorted = Object.entries(probabilities).sort((a, b) => b[1] - a[1]).slice(0, 3);
+    return (
+      <Box display="flex" gap={1} flexWrap="wrap">
+        {sorted.map(([label, value]) => (
+          <Chip key={label} label={`${label}: ${(value * 100).toFixed(1)}%`} size="small" color="primary" variant="outlined" />
+        ))}
+      </Box>
+    );
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Text</TableCell>
+            <TableCell>Expected</TableCell>
+            <TableCell>Predicted</TableCell>
+            <TableCell>Confidence</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {displayed.map((prediction) => {
+            const text = (prediction.inputs?.text as string) ?? '';
+            const isCorrect = prediction.expected_output === prediction.predicted_output;
+            return (
+              <TableRow key={prediction.uid} hover selected={!isCorrect}>
+                <TableCell sx={{ fontWeight: 600 }}>{prediction.uid}</TableCell>
+                <TableCell sx={{ maxWidth: 320 }}>
+                  <Typography variant="body2" noWrap title={text}>
+                    {text || '—'}
+                  </Typography>
+                </TableCell>
+                <TableCell>{String(prediction.expected_output ?? '—')}</TableCell>
+                <TableCell>
+                  <Typography color={isCorrect ? 'success.main' : 'error.main'}>
+                    {String(prediction.predicted_output ?? '—')}
+                  </Typography>
+                </TableCell>
+                <TableCell>{renderProbabilities(prediction.metadata ?? {})}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+};
+
+export default PredictionTable;

--- a/frontend/src/components/RunDetail.tsx
+++ b/frontend/src/components/RunDetail.tsx
@@ -1,0 +1,156 @@
+import { FC, useMemo } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { Metric, RunDetail as RunDetailType } from '../api';
+import MetricsCards from './MetricsCards';
+import PredictionTable from './PredictionTable';
+
+interface RunDetailProps {
+  run: RunDetailType | null;
+  loading: boolean;
+}
+
+const getMetricByName = (metrics: Metric[], name: string) =>
+  metrics.find((metric) => metric.name.toLowerCase() === name.toLowerCase());
+
+const RunDetail: FC<RunDetailProps> = ({ run, loading }) => {
+  const labelDistribution = useMemo(() => {
+    if (!run) return null;
+    const metric = getMetricByName(run.metrics, 'label_distribution');
+    if (!metric) return null;
+    const gold = metric.details?.gold as Record<string, number> | undefined;
+    const predicted = metric.details?.predicted as Record<string, number> | undefined;
+    if (!gold || !predicted) return null;
+    const labels = Array.from(new Set([...Object.keys(gold), ...Object.keys(predicted)]));
+    return labels.map((label) => ({
+      label,
+      gold: gold[label] ?? 0,
+      predicted: predicted[label] ?? 0
+    }));
+  }, [run]);
+
+  const confusionMatrix = useMemo(() => {
+    if (!run) return null;
+    const metric = getMetricByName(run.metrics, 'confusion_matrix');
+    if (!metric) return null;
+    const labels = (metric.details?.labels as string[]) ?? [];
+    const matrix = (metric.details?.matrix as number[][]) ?? [];
+    return { labels, matrix };
+  }, [run]);
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!run) {
+    return (
+      <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="body1" color="text.secondary">
+          Select a run from the left to inspect detailed metrics and predictions.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Paper variant="outlined" sx={{ p: 3 }}>
+        <Typography variant="h5" fontWeight={600} gutterBottom>
+          {run.name}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Config: {run.config_name} · Task: {run.task}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Started {new Date(run.started_at).toLocaleString()} · Completed {new Date(run.completed_at).toLocaleString()} ·
+          Duration {run.duration.toFixed(2)}s
+        </Typography>
+      </Paper>
+
+      <MetricsCards metrics={run.metrics} />
+
+      {labelDistribution && labelDistribution.length > 0 && (
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Label distribution
+          </Typography>
+          <Box sx={{ width: '100%', height: 300 }}>
+            <ResponsiveContainer>
+              <BarChart data={labelDistribution} margin={{ top: 16, right: 24, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="label" />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="gold" fill="#1976d2" name="Gold" />
+                <Bar dataKey="predicted" fill="#9c27b0" name="Predicted" />
+              </BarChart>
+            </ResponsiveContainer>
+          </Box>
+        </Paper>
+      )}
+
+      {confusionMatrix && confusionMatrix.labels.length > 0 && (
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Confusion matrix
+          </Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Gold \ Predicted</TableCell>
+                {confusionMatrix.labels.map((label) => (
+                  <TableCell key={label}>{label}</TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {confusionMatrix.matrix.map((row, rowIndex) => (
+                <TableRow key={confusionMatrix.labels[rowIndex]}>
+                  <TableCell component="th" scope="row" sx={{ fontWeight: 600 }}>
+                    {confusionMatrix.labels[rowIndex]}
+                  </TableCell>
+                  {row.map((value, columnIndex) => (
+                    <TableCell key={`${rowIndex}-${columnIndex}`}>{value}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      <Box>
+        <Typography variant="h6" gutterBottom>
+          Predictions
+        </Typography>
+        <PredictionTable predictions={run.predictions} />
+      </Box>
+    </Box>
+  );
+};
+
+export default RunDetail;

--- a/frontend/src/components/RunList.tsx
+++ b/frontend/src/components/RunList.tsx
@@ -1,0 +1,87 @@
+import { FC } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  List,
+  ListItemButton,
+  ListItemSecondaryAction,
+  ListItemText,
+  Paper,
+  Typography
+} from '@mui/material';
+import { RunSummary } from '../api';
+
+interface RunListProps {
+  runs: RunSummary[];
+  selectedRunId: number | null;
+  onSelect: (runId: number) => void;
+  loading?: boolean;
+}
+
+const RunList: FC<RunListProps> = ({ runs, selectedRunId, onSelect, loading = false }) => {
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (!runs.length) {
+    return (
+      <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No evaluations have been executed yet.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ maxHeight: 520, overflow: 'auto' }}>
+      <List disablePadding>
+        {runs.map((run) => {
+          const accuracyMetric = run.metrics.find((metric) => metric.name.toLowerCase().includes('accuracy'));
+          return (
+            <ListItemButton
+              key={run.id}
+              selected={selectedRunId === run.id}
+              onClick={() => onSelect(run.id)}
+              sx={{ alignItems: 'flex-start', py: 1.5 }}
+            >
+              <ListItemText
+                primary={
+                  <Typography variant="subtitle1" fontWeight={600} noWrap>
+                    {run.name}
+                  </Typography>
+                }
+                secondary={
+                  <>
+                    <Typography variant="body2" color="text.secondary">
+                      Completed {new Date(run.completed_at).toLocaleString()}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Config: {run.config_name}
+                    </Typography>
+                  </>
+                }
+              />
+              {accuracyMetric && (
+                <ListItemSecondaryAction>
+                  <Chip
+                    label={`Accuracy ${(accuracyMetric.value * 100).toFixed(1)}%`}
+                    color="primary"
+                    size="small"
+                  />
+                </ListItemSecondaryAction>
+              )}
+            </ListItemButton>
+          );
+        })}
+      </List>
+    </Paper>
+  );
+};
+
+export default RunList;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CssBaseline, ThemeProvider } from '@mui/material';
+import App from './App';
+import theme from './theme';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,14 @@
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background-color: #f7f9fc;
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,21 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#1976d2'
+    },
+    secondary: {
+      main: '#9c27b0'
+    },
+    background: {
+      default: '#f7f9fc'
+    }
+  },
+  typography: {
+    fontFamily: '"Inter", "Helvetica", "Arial", sans-serif'
+  }
+});
+
+export default theme;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ description = "Automation agent for evaluating AI models."
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "AI Assistant" }]
-dependencies = []
+dependencies = [
+    "fastapi>=0.103.0",
+    "uvicorn>=0.23.0",
+    "scikit-learn>=1.3.0",
+    "joblib>=1.3.0",
+]
 
 [project.scripts]
 evaluation-agent = "eval_agent.cli:main"

--- a/scripts/train_sentiment_model.py
+++ b/scripts/train_sentiment_model.py
@@ -1,0 +1,97 @@
+"""Train a scikit-learn sentiment analysis pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.metrics import classification_report
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_TRAIN_PATH = BASE_DIR / "data" / "sentiment_train.jsonl"
+DEFAULT_EVAL_PATH = BASE_DIR / "data" / "sentiment_eval.jsonl"
+DEFAULT_ARTIFACT_PATH = BASE_DIR / "artifacts" / "sentiment_pipeline.joblib"
+
+
+def read_jsonl(path: Path) -> Tuple[list[str], list[str]]:
+    texts: list[str] = []
+    labels: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            text = payload.get("text") or payload.get("input")
+            label = payload.get("label")
+            if text is None or label is None:
+                raise ValueError(f"Example missing 'text'/'label' fields in {path} -> {payload}")
+            texts.append(text)
+            labels.append(str(label))
+    return texts, labels
+
+
+def build_pipeline() -> Pipeline:
+    return Pipeline(
+        steps=[
+            ("tfidf", TfidfVectorizer(ngram_range=(1, 2), min_df=1, max_features=5000)),
+            (
+                "clf",
+                LogisticRegression(
+                    multi_class="auto",
+                    solver="lbfgs",
+                    max_iter=1000,
+                    class_weight="balanced",
+                ),
+            ),
+        ]
+    )
+
+
+def train(
+    train_path: Path,
+    eval_path: Path,
+    artifact_path: Path,
+) -> None:
+    train_texts, train_labels = read_jsonl(train_path)
+    eval_texts, eval_labels = read_jsonl(eval_path)
+
+    pipeline = build_pipeline()
+    pipeline.fit(train_texts, train_labels)
+
+    preds = pipeline.predict(eval_texts)
+    report = classification_report(eval_labels, preds, digits=3)
+
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(pipeline, artifact_path)
+
+    print("Saved model artifact to", artifact_path)
+    print("Evaluation report on validation split:\n")
+    print(report)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the bundled sentiment classifier.")
+    parser.add_argument("--train", type=Path, default=DEFAULT_TRAIN_PATH, help="Path to JSONL training data")
+    parser.add_argument("--eval", dest="eval_path", type=Path, default=DEFAULT_EVAL_PATH, help="Path to JSONL evaluation data")
+    parser.add_argument("--output", type=Path, default=DEFAULT_ARTIFACT_PATH, help="Where to write the trained pipeline artifact")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    train_path = args.train if args.train.is_absolute() else (BASE_DIR / args.train)
+    eval_path = args.eval_path if args.eval_path.is_absolute() else (BASE_DIR / args.eval_path)
+    artifact_path = args.output if args.output.is_absolute() else (BASE_DIR / args.output)
+
+    train(train_path=train_path, eval_path=eval_path, artifact_path=artifact_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval_agent/__init__.py
+++ b/src/eval_agent/__init__.py
@@ -9,6 +9,7 @@ from eval_agent.runner import EvaluationAgent, EvaluationResult
 from eval_agent.datasets import jsonl as _datasets_jsonl  # noqa: F401
 from eval_agent.metrics import classification as _metrics_classification  # noqa: F401
 from eval_agent.models import keyword as _models_keyword  # noqa: F401
+from eval_agent.models import sklearn as _models_sklearn  # noqa: F401
 from eval_agent.tasks import classification as _tasks_classification  # noqa: F401
 
 __all__ = [

--- a/src/eval_agent/api/__init__.py
+++ b/src/eval_agent/api/__init__.py
@@ -1,0 +1,5 @@
+"""API module for the evaluation agent."""
+
+from eval_agent.api.app import app
+
+__all__ = ["app"]

--- a/src/eval_agent/api/app.py
+++ b/src/eval_agent/api/app.py
@@ -1,0 +1,174 @@
+"""FastAPI application for orchestrating evaluation runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from eval_agent import EvaluationAgent, load_config
+from eval_agent.api.schemas import (
+    ConfigInfoSchema,
+    MetricSchema,
+    PredictionSchema,
+    RunCreateRequest,
+    RunDetailSchema,
+    RunSummarySchema,
+)
+from eval_agent.api.storage import RunStore
+from eval_agent.runner import EvaluationResult
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+RUNS_DIR = BASE_DIR / "runs"
+DEFAULT_DB_PATH = RUNS_DIR / "evaluations.db"
+
+PRESET_CONFIGS = {
+    "sentiment-keyword": BASE_DIR / "configs" / "sentiment_keyword.json",
+    "sentiment-sklearn": BASE_DIR / "configs" / "sentiment_sklearn.json",
+}
+
+app = FastAPI(title="Evaluation Agent API", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+store = RunStore(DEFAULT_DB_PATH)
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    store.initialize()
+
+
+def _resolve_config(config_identifier: str) -> tuple[str, Path]:
+    if config_identifier in PRESET_CONFIGS:
+        return config_identifier, PRESET_CONFIGS[config_identifier]
+
+    candidate = Path(config_identifier)
+    if not candidate.is_absolute():
+        potential = BASE_DIR / candidate
+        candidate = potential if potential.exists() else (Path.cwd() / candidate)
+    candidate = candidate.resolve()
+    if not candidate.exists():
+        raise HTTPException(status_code=404, detail=f"Configuration '{config_identifier}' not found")
+    return config_identifier, candidate
+
+
+def _result_to_schema(
+    *,
+    run_id: int,
+    config_name: str,
+    config_path: Path,
+    result: EvaluationResult,
+) -> RunDetailSchema:
+    metrics = [MetricSchema(**metric.to_dict()) for metric in result.metrics]
+    predictions = [PredictionSchema(**prediction.to_dict()) for prediction in result.predictions]
+    duration = (result.completed_at - result.started_at).total_seconds()
+    return RunDetailSchema(
+        id=run_id,
+        name=result.name,
+        task=result.task,
+        config_name=config_name,
+        config_path=str(config_path),
+        started_at=result.started_at,
+        completed_at=result.completed_at,
+        duration=duration,
+        metrics=metrics,
+        predictions=predictions,
+    )
+
+
+def _record_to_summary(record) -> RunSummarySchema:
+    metrics = [MetricSchema(**metric) for metric in record.metrics]
+    return RunSummarySchema(
+        id=record.id,
+        name=record.name,
+        task=record.task,
+        config_name=record.config_name,
+        config_path=record.config_path,
+        started_at=record.started_at,
+        completed_at=record.completed_at,
+        duration=record.duration,
+        metrics=metrics,
+    )
+
+
+def _record_to_detail(record) -> RunDetailSchema:
+    predictions_payload = _load_predictions(record.predictions_path)
+    metrics = [MetricSchema(**metric) for metric in record.metrics]
+    predictions = [PredictionSchema(**item) for item in predictions_payload]
+    return RunDetailSchema(
+        id=record.id,
+        name=record.name,
+        task=record.task,
+        config_name=record.config_name,
+        config_path=record.config_path,
+        started_at=record.started_at,
+        completed_at=record.completed_at,
+        duration=record.duration,
+        metrics=metrics,
+        predictions=predictions,
+    )
+
+
+def _load_predictions(path: str | None) -> List[dict]:
+    if not path:
+        return []
+    candidate = Path(path)
+    if not candidate.exists():
+        return []
+    try:
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    predictions = payload.get("predictions")
+    if isinstance(predictions, list):
+        return predictions
+    return []
+
+
+@app.get("/api/health")
+def healthcheck() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/api/configs", response_model=List[ConfigInfoSchema])
+def list_configs() -> List[ConfigInfoSchema]:
+    return [
+        ConfigInfoSchema(name=name, path=str(path), description=f"Preset config located at {path}")
+        for name, path in PRESET_CONFIGS.items()
+    ]
+
+
+@app.get("/api/runs", response_model=List[RunSummarySchema])
+def list_runs() -> List[RunSummarySchema]:
+    records = store.list_runs()
+    return [_record_to_summary(record) for record in records]
+
+
+@app.get("/api/runs/{run_id}", response_model=RunDetailSchema)
+def get_run(run_id: int) -> RunDetailSchema:
+    record = store.get_run(run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Run with id {run_id} not found")
+    return _record_to_detail(record)
+
+
+@app.post("/api/runs", response_model=RunDetailSchema)
+def create_run(request: RunCreateRequest) -> RunDetailSchema:
+    config_name, config_path = _resolve_config(request.config)
+    config = load_config(config_path)
+    if request.save_predictions is not None:
+        config.output.save_predictions = request.save_predictions
+
+    agent = EvaluationAgent(config)
+    result = agent.run()
+
+    run_id = store.record_run(config_name=config_name, config_path=config_path, result=result)
+    return _result_to_schema(run_id=run_id, config_name=config_name, config_path=config_path, result=result)

--- a/src/eval_agent/api/schemas.py
+++ b/src/eval_agent/api/schemas.py
@@ -1,0 +1,52 @@
+"""Pydantic schemas for the evaluation API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MetricSchema(BaseModel):
+    name: str
+    value: float
+    details: Dict[str, Any]
+
+
+class PredictionSchema(BaseModel):
+    uid: str
+    inputs: Dict[str, Any]
+    expected_output: Any
+    predicted_output: Any
+    metadata: Dict[str, Any]
+
+
+class RunSummarySchema(BaseModel):
+    id: int
+    name: str
+    task: str
+    config_name: str
+    config_path: str
+    started_at: datetime
+    completed_at: datetime
+    duration: float = Field(..., description="Duration of the run in seconds")
+    metrics: List[MetricSchema]
+
+
+class RunDetailSchema(RunSummarySchema):
+    predictions: List[PredictionSchema]
+
+
+class RunCreateRequest(BaseModel):
+    config: str = Field(..., description="Either a preset name or an absolute/relative path to a config file")
+    save_predictions: Optional[bool] = Field(
+        None,
+        description="Override the configuration output.save_predictions flag.",
+    )
+
+
+class ConfigInfoSchema(BaseModel):
+    name: str
+    path: str
+    description: Optional[str] = None

--- a/src/eval_agent/api/storage.py
+++ b/src/eval_agent/api/storage.py
@@ -1,0 +1,146 @@
+"""SQLite persistence for evaluation runs."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from eval_agent.runner import EvaluationResult
+
+
+@dataclass
+class RunRecord:
+    id: int
+    name: str
+    task: str
+    config_name: str
+    config_path: str
+    started_at: datetime
+    completed_at: datetime
+    duration: float
+    metrics: list[dict]
+    predictions_path: str | None
+
+
+class RunStore:
+    """Lightweight SQLite-backed store for evaluation runs."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def initialize(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    task TEXT NOT NULL,
+                    config_name TEXT NOT NULL,
+                    config_path TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT NOT NULL,
+                    duration REAL NOT NULL,
+                    metrics_json TEXT NOT NULL,
+                    predictions_path TEXT
+                );
+                """
+            )
+            connection.commit()
+
+    def record_run(
+        self,
+        *,
+        config_name: str,
+        config_path: Path,
+        result: EvaluationResult,
+    ) -> int:
+        metrics_json = json.dumps([metric.to_dict() for metric in result.metrics])
+        predictions_path = str(result.output_path) if result.output_path else None
+        duration = (result.completed_at - result.started_at).total_seconds()
+        with sqlite3.connect(self.path) as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO runs (
+                    name,
+                    task,
+                    config_name,
+                    config_path,
+                    started_at,
+                    completed_at,
+                    duration,
+                    metrics_json,
+                    predictions_path
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    result.name,
+                    result.task,
+                    config_name,
+                    str(config_path),
+                    result.started_at.isoformat(),
+                    result.completed_at.isoformat(),
+                    duration,
+                    metrics_json,
+                    predictions_path,
+                ),
+            )
+            connection.commit()
+            return int(cursor.lastrowid)
+
+    def list_runs(self) -> List[RunRecord]:
+        with sqlite3.connect(self.path) as connection:
+            cursor = connection.execute(
+                """
+                SELECT id, name, task, config_name, config_path, started_at, completed_at, duration, metrics_json, predictions_path
+                FROM runs
+                ORDER BY completed_at DESC
+                """
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_record(row) for row in rows]
+
+    def get_run(self, run_id: int) -> Optional[RunRecord]:
+        with sqlite3.connect(self.path) as connection:
+            cursor = connection.execute(
+                """
+                SELECT id, name, task, config_name, config_path, started_at, completed_at, duration, metrics_json, predictions_path
+                FROM runs
+                WHERE id = ?
+                """,
+                (run_id,),
+            )
+            row = cursor.fetchone()
+        return self._row_to_record(row) if row else None
+
+    def _row_to_record(self, row: Iterable) -> RunRecord:
+        (
+            run_id,
+            name,
+            task,
+            config_name,
+            config_path,
+            started_at,
+            completed_at,
+            duration,
+            metrics_json,
+            predictions_path,
+        ) = row
+        metrics = json.loads(metrics_json) if metrics_json else []
+        return RunRecord(
+            id=int(run_id),
+            name=str(name),
+            task=str(task),
+            config_name=str(config_name),
+            config_path=str(config_path),
+            started_at=datetime.fromisoformat(str(started_at)),
+            completed_at=datetime.fromisoformat(str(completed_at)),
+            duration=float(duration),
+            metrics=metrics,
+            predictions_path=str(predictions_path) if predictions_path else None,
+        )

--- a/src/eval_agent/cli.py
+++ b/src/eval_agent/cli.py
@@ -6,34 +6,18 @@ import argparse
 import json
 import logging
 from pathlib import Path
+from typing import Callable
 
 from eval_agent import EvaluationAgent, load_config
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run evaluation agent workflows.")
-    parser.add_argument("config", type=Path, help="Path to the evaluation configuration JSON file.")
-    parser.add_argument(
-        "--no-predictions",
-        action="store_true",
-        help="Do not print individual predictions to stdout.",
-    )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
-        help="Logging level for the run.",
-    )
-    return parser
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level), format="%(levelname)s: %(message)s")
 
 
-def main(argv: list[str] | None = None) -> None:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    logging.basicConfig(level=getattr(logging, args.log_level), format="%(levelname)s: %(message)s")
+def _run_command(args: argparse.Namespace) -> None:
+    _configure_logging(args.log_level)
     config = load_config(args.config)
-    # Override saving predictions flag if requested.
     if args.no_predictions:
         config.output.save_predictions = False
 
@@ -46,13 +30,73 @@ def main(argv: list[str] | None = None) -> None:
         "metrics": [metric.to_dict() for metric in result.metrics],
         "output_path": str(result.output_path) if result.output_path else None,
     }
-
     print(json.dumps(summary, indent=2))
 
     if not args.no_predictions:
         print("\nPredictions:")
         for prediction in result.predictions:
             print(json.dumps(prediction.to_dict(), ensure_ascii=False))
+
+
+def _serve_command(args: argparse.Namespace) -> None:
+    _configure_logging(args.log_level)
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise SystemExit("uvicorn must be installed to use the serve command") from exc
+
+    uvicorn.run(
+        "eval_agent.api.app:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        log_level=args.log_level.lower(),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run evaluation agent workflows and services.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Execute an evaluation configuration once.")
+    run_parser.add_argument("config", type=Path, help="Path to the evaluation configuration JSON file.")
+    run_parser.add_argument(
+        "--no-predictions",
+        action="store_true",
+        help="Do not print individual predictions to stdout.",
+    )
+    run_parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Logging level for the run.",
+    )
+    run_parser.set_defaults(func=_run_command)
+
+    serve_parser = subparsers.add_parser("serve", help="Launch the FastAPI service.")
+    serve_parser.add_argument("--host", default="0.0.0.0", help="Host interface to bind the API server.")
+    serve_parser.add_argument("--port", type=int, default=8000, help="Port for the API server.")
+    serve_parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable autoreload (useful during development).",
+    )
+    serve_parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Logging level for the API server.",
+    )
+    serve_parser.set_defaults(func=_serve_command)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func: Callable[[argparse.Namespace], None] = getattr(args, "func")
+    func(args)
 
 
 if __name__ == "__main__":

--- a/src/eval_agent/metrics/classification.py
+++ b/src/eval_agent/metrics/classification.py
@@ -2,12 +2,86 @@
 
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 from typing import Dict, Sequence
 
 from eval_agent.metrics.base import Metric
 from eval_agent.registry import METRIC_REGISTRY
 from eval_agent.types import Example, MetricResult, ModelResponse
+
+
+def _safe_div(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def _gather_classification_stats(
+    examples: Sequence[Example],
+    responses: Sequence[ModelResponse],
+):
+    labels_set: set[str] = set()
+    tp = defaultdict(int)
+    fp = defaultdict(int)
+    fn = defaultdict(int)
+    support = defaultdict(int)
+    confusion = defaultdict(lambda: defaultdict(int))
+
+    for example, response in zip(examples, responses):
+        gold = str(example.expected_output)
+        pred = str(response.output)
+        labels_set.add(gold)
+        labels_set.add(pred)
+        support[gold] += 1
+        confusion[gold][pred] += 1
+        if gold == pred:
+            tp[gold] += 1
+        else:
+            fn[gold] += 1
+            fp[pred] += 1
+
+    labels = sorted(labels_set)
+    totals = {
+        "tp": sum(tp.values()),
+        "fp": sum(fp.values()),
+        "fn": sum(fn.values()),
+    }
+    return labels, tp, fp, fn, support, confusion, totals
+
+
+def _aggregate_scores(
+    per_label: Dict[str, float],
+    support: Dict[str, int],
+    average: str,
+    *,
+    totals: Dict[str, int],
+    score: str,
+) -> float:
+    labels = list(per_label.keys())
+    if not labels:
+        return 0.0
+
+    if average == "macro":
+        return sum(per_label[label] for label in labels) / len(labels)
+    if average == "weighted":
+        total_support = sum(support.get(label, 0) for label in labels)
+        if not total_support:
+            return 0.0
+        return sum(per_label[label] * support.get(label, 0) for label in labels) / total_support
+    if average == "micro":
+        tp = totals["tp"]
+        fp = totals["fp"]
+        fn = totals["fn"]
+        if score == "precision":
+            return _safe_div(tp, tp + fp)
+        if score == "recall":
+            return _safe_div(tp, tp + fn)
+        if score == "f1":
+            precision_micro = _safe_div(tp, tp + fp)
+            recall_micro = _safe_div(tp, tp + fn)
+            if precision_micro + recall_micro == 0:
+                return 0.0
+            return 2 * precision_micro * recall_micro / (precision_micro + recall_micro)
+        raise ValueError(f"Unsupported score '{score}' for micro average")
+    raise ValueError(f"Unsupported average '{average}'. Use 'macro', 'weighted', or 'micro'.")
 
 
 @METRIC_REGISTRY.register("accuracy")
@@ -28,6 +102,112 @@ class AccuracyMetric(Metric):
         value = (correct / total) if total else 0.0
         details = {"correct": correct, "total": total}
         return MetricResult(name=self.name, value=value, details=details)
+
+
+@METRIC_REGISTRY.register("precision")
+class PrecisionMetric(Metric):
+    """Compute precision for classification tasks."""
+
+    def __init__(self, *, average: str = "macro", name: str | None = None) -> None:
+        super().__init__(name=name)
+        self.average = average
+
+    def compute(
+        self,
+        *,
+        examples: Sequence[Example],
+        responses: Sequence[ModelResponse],
+    ) -> MetricResult:
+        labels, tp, fp, fn, support, _confusion, totals = _gather_classification_stats(examples, responses)
+        per_label = {label: _safe_div(tp[label], tp[label] + fp[label]) for label in labels}
+        value = _aggregate_scores(per_label, support, self.average, totals=totals, score="precision")
+        details = {
+            "average": self.average,
+            "per_label": per_label,
+            "support": {label: int(support[label]) for label in labels},
+        }
+        return MetricResult(name=self.name, value=value, details=details)
+
+
+@METRIC_REGISTRY.register("recall")
+class RecallMetric(Metric):
+    """Compute recall for classification tasks."""
+
+    def __init__(self, *, average: str = "macro", name: str | None = None) -> None:
+        super().__init__(name=name)
+        self.average = average
+
+    def compute(
+        self,
+        *,
+        examples: Sequence[Example],
+        responses: Sequence[ModelResponse],
+    ) -> MetricResult:
+        labels, tp, fp, fn, support, _confusion, totals = _gather_classification_stats(examples, responses)
+        per_label = {label: _safe_div(tp[label], tp[label] + fn[label]) for label in labels}
+        value = _aggregate_scores(per_label, support, self.average, totals=totals, score="recall")
+        details = {
+            "average": self.average,
+            "per_label": per_label,
+            "support": {label: int(support[label]) for label in labels},
+        }
+        return MetricResult(name=self.name, value=value, details=details)
+
+
+@METRIC_REGISTRY.register("f1")
+class F1ScoreMetric(Metric):
+    """Compute the F1-score for classification tasks."""
+
+    def __init__(self, *, average: str = "macro", name: str | None = None) -> None:
+        super().__init__(name=name)
+        self.average = average
+
+    def compute(
+        self,
+        *,
+        examples: Sequence[Example],
+        responses: Sequence[ModelResponse],
+    ) -> MetricResult:
+        labels, tp, fp, fn, support, _confusion, totals = _gather_classification_stats(examples, responses)
+        per_label_precision = {label: _safe_div(tp[label], tp[label] + fp[label]) for label in labels}
+        per_label_recall = {label: _safe_div(tp[label], tp[label] + fn[label]) for label in labels}
+        per_label = {}
+        for label in labels:
+            precision = per_label_precision[label]
+            recall = per_label_recall[label]
+            if precision + recall == 0:
+                per_label[label] = 0.0
+            else:
+                per_label[label] = 2 * precision * recall / (precision + recall)
+        value = _aggregate_scores(per_label, support, self.average, totals=totals, score="f1")
+        details = {
+            "average": self.average,
+            "per_label": per_label,
+            "support": {label: int(support[label]) for label in labels},
+        }
+        return MetricResult(name=self.name, value=value, details=details)
+
+
+@METRIC_REGISTRY.register("confusion-matrix")
+class ConfusionMatrixMetric(Metric):
+    """Compute a confusion matrix."""
+
+    def compute(
+        self,
+        *,
+        examples: Sequence[Example],
+        responses: Sequence[ModelResponse],
+    ) -> MetricResult:
+        labels, _tp, _fp, _fn, _support, confusion, _totals = _gather_classification_stats(examples, responses)
+        matrix = [
+            [int(confusion[gold].get(pred, 0)) for pred in labels]
+            for gold in labels
+        ]
+        details = {
+            "labels": labels,
+            "matrix": matrix,
+        }
+        return MetricResult(name=self.name, value=1.0, details=details)
 
 
 @METRIC_REGISTRY.register("label-distribution")

--- a/src/eval_agent/models/sklearn.py
+++ b/src/eval_agent/models/sklearn.py
@@ -1,0 +1,79 @@
+"""scikit-learn pipeline adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import joblib
+
+from eval_agent.models.base import ModelAdapter
+from eval_agent.registry import MODEL_REGISTRY
+from eval_agent.types import Example, ModelResponse
+
+
+@MODEL_REGISTRY.register("sklearn-pipeline")
+class SklearnPipelineModel(ModelAdapter):
+    """Model adapter that loads a serialized scikit-learn pipeline via joblib."""
+
+    def __init__(
+        self,
+        *,
+        artifact_path: str | Path,
+        label_mapping: dict[str, str] | None = None,
+        probability_field: str = "probabilities",
+        name: str | None = None,
+        warmup_examples: int = 0,
+    ) -> None:
+        super().__init__(name=name)
+        self.artifact_path = Path(artifact_path)
+        if not self.artifact_path.exists():
+            raise FileNotFoundError(f"Model artifact not found at {self.artifact_path}")
+        self.pipeline = joblib.load(self.artifact_path)
+        self.label_mapping = {str(key): value for key, value in (label_mapping or {}).items()}
+        self.probability_field = probability_field
+        self.warmup_examples = warmup_examples
+        self._classes: list[str] | None = None
+        classes = getattr(self.pipeline, "classes_", None)
+        if classes is not None:
+            self._classes = [self._map_label(label) for label in classes]
+
+    def _map_label(self, label: Any) -> Any:
+        return self.label_mapping.get(str(label), label)
+
+    def warmup(self, examples: Iterable[Example] | None = None) -> None:
+        if not self.warmup_examples:
+            return
+        iterable = list(examples or [])[: self.warmup_examples]
+        if not iterable:
+            return
+        texts = [example.text() for example in iterable]
+        if hasattr(self.pipeline, "predict"):
+            self.pipeline.predict(texts)
+        if hasattr(self.pipeline, "predict_proba"):
+            try:
+                self.pipeline.predict_proba(texts)
+            except Exception:
+                # Some estimators raise when predict_proba is not available; ignore.
+                pass
+
+    def predict(self, example: Example) -> ModelResponse:
+        text = example.text()
+        raw_output = self.pipeline.predict([text])[0]
+        mapped_output = self._map_label(raw_output)
+
+        metadata: dict[str, Any] = {"model_name": self.name, "artifact_path": str(self.artifact_path)}
+        if hasattr(self.pipeline, "predict_proba"):
+            try:
+                probabilities = self.pipeline.predict_proba([text])[0]
+                classes = self._classes or getattr(self.pipeline, "classes_", None)
+                if classes is not None:
+                    metadata[self.probability_field] = {
+                        str(self._map_label(label)): float(prob)
+                        for label, prob in zip(classes, probabilities)
+                    }
+            except Exception:
+                # Ignore probability errors for estimators that do not implement it.
+                pass
+
+        return ModelResponse(uid=example.uid, output=mapped_output, metadata=metadata)

--- a/src/eval_agent/runner.py
+++ b/src/eval_agent/runner.py
@@ -54,6 +54,7 @@ class EvaluationAgent:
         )
         model = MODEL_REGISTRY.create(self.config.model.type, **self.config.model.parameters)
         task = TASK_REGISTRY.create(self.config.task, dataset, model)
+        task.warmup(dataset.examples())
 
         metric_instances = self._build_metrics(self.config.metrics)
 

--- a/tests/test_evaluation_agent.py
+++ b/tests/test_evaluation_agent.py
@@ -25,6 +25,17 @@ def test_keyword_model_evaluation(tmp_path: Path) -> None:
     assert accuracy.details["total"] == 6
     assert accuracy.details["correct"] == 6
 
+    metrics = {metric.name: metric for metric in result.metrics}
+    assert metrics["precision_macro"].value == 1.0
+    assert metrics["recall_macro"].value == 1.0
+    assert metrics["f1_macro"].value == 1.0
+
+    confusion = metrics["confusion_matrix"].details
+    labels = confusion["labels"]
+    matrix = confusion["matrix"]
+    assert len(labels) == len(matrix)
+    assert sum(matrix[i][i] for i in range(len(labels))) == len(result.predictions)
+
     saved_payload = json.loads(result.output_path.read_text(encoding="utf-8"))
     assert saved_payload["name"] == "sentiment-keyword-baseline"
     assert saved_payload["metrics"][0]["name"] == "accuracy"


### PR DESCRIPTION
## Summary
- add a scikit-learn sentiment preset, training script, and richer classification metrics
- introduce a FastAPI service with SQLite persistence plus CLI support for serving it
- scaffold a React dashboard that visualises run history, metrics, and predictions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdff41627c8328bce1cdec381233b1